### PR TITLE
chore: upgrade Elasticsearch to 8.19.18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
 
 services:
   elasticsearch:
-    image: elasticsearch:8.13.0
+    image: elasticsearch:8.19.18
     restart: unless-stopped
     networks:
       - app


### PR DESCRIPTION
Bump the shared Elasticsearch cluster image `8.13.0` → `8.19.18` (latest 8.x).

Part of a coordinated Elasticsearch 8.19 upgrade across the three repos that share this cluster:
- event-database-services (this) — the cluster image
- event-database-imports — override image + `elasticsearch/elasticsearch` client `^8.19`
- event-database-api — override image + client `^8.19`

Within-major (8.13 → 8.19) is backward-compatible per Elastic's support policy. Roll this cluster upgrade out first/together with the client apps.